### PR TITLE
separate requirements.txt step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM python:3.6-alpine
 RUN mkdir /pip /code
 WORKDIR /pip
 ADD requirements.txt /pip
-RUN apk add --no-cache --virtual build-dependencies gcc musl-dev make && pip install -r requirements.txt && apk del build-dependencies
+RUN apk add --no-cache --virtual build-dependencies gcc musl-dev make
+RUN pip install -r requirements.txt && apk del build-dependencies
 WORKDIR /code
 
 # this is over-ridden by the `gunicorn.sh` entrypoint which uses gunicorn/uvloop:


### PR DESCRIPTION
@richardkiss: I broke out the base and requirements so that changes to `requirements.txt` have faster builds (when using the cache). Of course this does mean more cache hits on docker builds generally :(